### PR TITLE
Markdown linebreak trick

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -4,4 +4,5 @@
  * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
  */
 
+$conf['markdown']  = 0;
 $conf['linebreak'] = 'LF'; // = DOKU_LF

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,4 +4,5 @@
  * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
  */
 
+$meta['markdown']  = array('onoff');
 $meta['linebreak'] = array('multichoice','_choices' => array('LF','br',''));

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * DokuWiki Plugin LineBreak2;
- * English language file
+ * English language file for settings
  *
  * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
  */
 
+$lang['markdown']  = 'Treat more than two spaces at end of line as &lt;br&gt; (the Markdown trick emulation)';
 $lang['linebreak'] = 'How to treat line break in cdata() call';
 $lang['linebreak_o_LF'] ='output as is (default)';
 $lang['linebreak_o_br'] ='replace to <br> tag';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * DokuWiki Plugin LineBreak2;
- * Japanese language file
+ * Japanese language file for settings
  *
  * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
  */
 
+$lang['markdown']  = '行末にスペース2つ以上がある場合、&lt;br&gt; タグで改行 (Markdown記法と同様)';
 $lang['linebreak'] = 'LineBreak2 レンダラーでの改行文字の取り扱い方';
 $lang['linebreak_o_LF']  ='出力する（標準xhtmlレンダラーと同じ）';
 $lang['linebreak_o_br']  ='<br> タグに置換';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base     linebreak2
 author   Satoshi Sahara
 email    sahara.satoshi@gmail.com
-date     2016-07-12
+date     2016-07-16
 name     LineBreak2 plugin
-desc     Alternative xhtml renderer that works with LINEBREAK directive syntax influences whether linebreaks in the wiki text should be preserved or removed.
+desc     Alternative xhtml renderer that works with LINEBREAK directive syntax influences whether linebreaks in the wiki text should be preserved or removed. The LineBreak2 renderer optinally emulates Markdown linebreak trick.
 url      https://github.com/ssahara/dw-plugin-linebreak2

--- a/renderer.php
+++ b/renderer.php
@@ -31,6 +31,13 @@ class renderer_plugin_linebreak2 extends Doku_Renderer_xhtml {
     function cdata($text) {
         global $INFO;
 
+        // Markdown linebreak syntax (more than two spaces at the end of line)
+        if ($this->getConf('markdown')) {
+            $html = preg_replace('/ {2,}\n/', '<br />', $this->_xmlEntities($text));
+        } else {
+            $html = $this->_xmlEntities($text);
+        }
+
         // check LINEBREAK directive in the page metadata
         if (isset($INFO['meta']['plugin_linebreak2'])) {
             $linebreak = $INFO['meta']['plugin_linebreak2'];
@@ -41,16 +48,16 @@ class renderer_plugin_linebreak2 extends Doku_Renderer_xhtml {
         switch ($linebreak) {
             case 'br':
                 // xbr plugin: XHTML output with preserved linebreaks
-                $this->doc .= str_replace(DOKU_LF,'<br />'.DOKU_LF,$this->_xmlEntities($text));
+                $this->doc .= str_replace(DOKU_LF, '<br />', $html);
                 return;
             case '':
                 // scriptio continua: concatenate next line without word delimiting space
-                $this->doc .= str_replace(DOKU_LF,'',$this->_xmlEntities($text));
+                $this->doc .= str_replace(DOKU_LF, '', $html);
                 return;
             case 'LF':
             default:
                 // leave line break chars as is (identical with the standard xhml renderer)
-                $this->doc .= $this->_xmlEntities($text);
+                $this->doc .= $html;
                 return;
         }
     }


### PR DESCRIPTION
The LineBreak2 renderer optinally emulates Markdown linebreak trick.
More than two spaces at the end of line will be rendered as `<br>` tag. (default off)
